### PR TITLE
jackson-databind-nullable追加v0.2.11

### DIFF
--- a/samples/basic-sample/pom.xml
+++ b/samples/basic-sample/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>jp.co.freee</groupId>
       <artifactId>freee-accounting-sdk</artifactId>
-      <version>2.10.0</version>
+      <version>2.11.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/samples/basic-websample-rx/pom.xml
+++ b/samples/basic-websample-rx/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>jp.co.freee</groupId>
             <artifactId>freee-accounting-sdk</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>

--- a/samples/basic-websample/pom.xml
+++ b/samples/basic-websample/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>jp.co.freee</groupId>
             <artifactId>freee-accounting-sdk</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -276,6 +276,12 @@
       <version>${jakarta-annotation-version}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.openapitools/jackson-databind-nullable -->
+    <dependency>
+      <groupId>org.openapitools</groupId>
+      <artifactId>jackson-databind-nullable</artifactId>
+      <version>0.2.1</version>
+    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
ビルド時に依存が不足するので、下記と同じ対応
https://github.com/freee/freee-accounting-sdk-java/pull/66