### PR TITLE
fix(sec): upgrade org.webjars:jquery to 3.5.0

### DIFF
--- a/samples/basic-websample-rx/pom.xml
+++ b/samples/basic-websample-rx/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.4.1</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/samples/basic-websample/pom.xml
+++ b/samples/basic-websample/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.4.1</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.webjars:jquery 3.4.1
- [CVE-2020-11022](https://www.oscs1024.com/hd/CVE-2020-11022)


### What did I do？
Upgrade org.webjars:jquery from 3.4.1 to 3.5.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS